### PR TITLE
Minor fix for apply_shifts and demo.m

### DIFF
--- a/apply_shifts.m
+++ b/apply_shifts.m
@@ -118,6 +118,7 @@ if strcmpi(options.shifts_method,'fft');
     end
     if nd == 2; Np = cellfun(@(x) 0,Nr,'un',0); end
     shift_fun = @(yfft,shfts,ph,nr,nc,np) shift_reconstruct(yfft,shfts,ph,options.us_fac,nr,nc,np,options.boundary,0);
+    Xq = []; Yq = []; Zq = [];
 else
     if nd == 3
         dim = [d1,d2,d3];

--- a/demo.m
+++ b/demo.m
@@ -15,7 +15,7 @@ end
 tic; Y = read_file(name); toc; % read the file (optional, you can also pass the path in the function instead of Y)
 Y = single(Y);                 % convert to single precision 
 T = size(Y,ndims(Y));
-%Y = Y - min(Y(:));
+Y = Y - min(Y(:));
 %% set parameters (first try out rigid motion correction)
 
 options_rigid = NoRMCorreSetParms('d1',size(Y,1),'d2',size(Y,2),'bin_width',200,'max_shift',15,'us_fac',50,'init_batch',200);


### PR DESCRIPTION
Hi Eftychios, thanks again for the great work!
I find that in apply_shifts, I need an additional line setting up Xq/Yq/Zq when using 'fft'.
Another occasional problem I encountered when using NoRMCorre was that with images that have significant numbers of negative value pixels, the fft registration would produce global phase differences of pi or -pi, and in result, invert the images in terms of pixel intensity.  A simple fix to this (I haven't fully explored whether this is a bug or an inevitable result of fft-based registration) is to ensure all pixels are non-negative at start. You had commented this out some time ago, I simply reinstated it.  Hope this helps.
Cheers! 
-Ingie