### PR TITLE
Prevent normcorre from failing if shifts are too large relative to patch size

### DIFF
--- a/remove_boundaries.m
+++ b/remove_boundaries.m
@@ -18,6 +18,17 @@ if strcmpi(method,'nan');
     add_value = NaN;
 end
 
+% Make sure shifts are not larger than size of image/patch (to prevent
+% crashes, and issue a warning if shifts are too large. 
+if abs( shifts(1) ) >= sz(1)
+    shifts(1) = sign(shifts(1)) * (sz(1)-1);
+    warning('Detected y-shifts are larger than height of patches. Consider inceasing the height of patches!')
+end
+if abs( shifts(2) ) >= sz(2)
+    shifts(2) = sign(shifts(2)) * (sz(2)-1);
+    warning('Detected x-shifts are larger than width of patches. Consider inceasing the width of patches!')
+end
+
 switch lower(method)
     case 'zero'
         if shifts(1); X((1:abs(shifts(1)))*sign(shifts(1)) + (sz(1)+1)*(shifts(1)<0),:,:) = add_value; end


### PR DESCRIPTION
We have occasional failures when running NoRMCorre on very sparse data or data with occasional very large movements. The error happens in the remove_boundaries function, and this is a proposed workaround to prevent normcorre from aborting.

Sometimes the big movements are only present in a subset of frames and its better to have the corrected result with some frames being suboptimal than spending time debugging and trying to find a better grid size. 

I added a warning whenever the shifts are to large relative to the grid_size, but this might mess up the command line, so maybe it should only be displayed once (i.e use a persistent variable to skip showing warning multiple times) or be connected to the verbosity levels.



